### PR TITLE
Add DB Zugbildungsplan to JSON project

### DIFF
--- a/projects/db-zugbildungsplan-json.json
+++ b/projects/db-zugbildungsplan-json.json
@@ -1,0 +1,35 @@
+{
+  "name": "DB Fernverkehr-Zugbildungsplan als JSON",
+  "desc": "Maschinenlesbare JSON-Beschreibung des von DB Fernverkehr veröffentlichten Zugbildungsplans",
+  "url": "https://lib.finalrewind.org/dbdb/db_zugbildung_latest.json",
+  "type": "projects",
+  "links": {
+    "github": "https://github.com/derf/db-zugbildung-to-json",
+    "twitter": "derfnull"
+  },
+  "tags": [
+    "DB",
+    "Data",
+    "Fernverkehr",
+    "Zug"
+  ],
+  "creators": [
+    ["Datengrundlage:", "DB Fernverkehr AG"],
+    ["Aufbereitung:", "Daniel Friesel"]
+  ],
+  "no-permission": [
+  ],
+  "permissions": [
+  ],
+  "licenses": [
+    "CC-BY-4.0"
+  ],
+  "contacts": [
+    "derf"
+  ],
+  "maintainers": [
+    "derf"
+  ],
+  "addedAt": "2020-12-22",
+  "status": "development"
+}


### PR DESCRIPTION
This site (or rather, JSON file) provides a JSON version of the PDF Zugbildungsplan published on the DB Open Data platform. Source code and OpenAPI spec are on Github.